### PR TITLE
Fix crash on artwork being null

### DIFF
--- a/structures/activity.js
+++ b/structures/activity.js
@@ -70,7 +70,7 @@ module.exports = (config, rpc) => {
         state: `by ${track_data.user.username}`,
         startTimestamp,
         endTimestamp,
-        largeImageKey: track_data.artwork_url,
+        largeImageKey: track_data.artwork_url ?? 'https://imgur.com/a/T3Bp7nq',
         largeImageText: track_data.title,
         smallImageKey: "https://i.imgur.com/kL9JNVF.png",
         smallImageText: track_data.user.username,

--- a/structures/activity.js
+++ b/structures/activity.js
@@ -70,7 +70,7 @@ module.exports = (config, rpc) => {
         state: `by ${track_data.user.username}`,
         startTimestamp,
         endTimestamp,
-        largeImageKey: track_data.artwork_url ?? 'https://imgur.com/a/T3Bp7nq',
+        largeImageKey: track_data.artwork_url ?? "https://i.imgur.com/jus7rW5.jpeg",
         largeImageText: track_data.title,
         smallImageKey: "https://i.imgur.com/kL9JNVF.png",
         smallImageText: track_data.user.username,


### PR DESCRIPTION
When attempting to load a track that has the default artwork, the application will crash as SoundCloud's API returns null for track_data.artwork_url. This change will check if the data is null and if it is, it will use https://imgur.com/a/T3Bp7nq as the largeImageKey instead.